### PR TITLE
fix: Update_github_actions_libraries INFRA-106

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ^1.17
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
## Update GitHub actions libraries:

- actions/setup-go: Upgraded library from 2 to 3, [to upgrade to NodeJS 16 is required version 3.0 or higher.](https://github.com/actions/setup-go/releases)

- actions/checkout: Upgraded library from 2 to 3, [to upgrade to NodeJS 16 requires version 3.0.0 or higher.](https://github.com/actions/checkout/releases)